### PR TITLE
fix(macos): add macos instructions and helpers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 BUILD_DIR := build
 
+# Allow the user to specify the compiler and linker on macOS
+# as Apple Clang does not support MIPS architecture
 ifeq ($(shell uname),Darwin)
     CC      ?= clang
     LD      ?= ld.lld

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,13 @@
 BUILD_DIR := build
 
-CC      := clang
-LD      := ld.lld
+ifeq ($(shell uname),Darwin)
+    CC      ?= clang
+    LD      ?= ld.lld
+else
+    CC      := clang
+    LD      := ld.lld
+endif
+
 TARGET  := $(BUILD_DIR)/mod.elf
 
 LDSCRIPT := mod.ld

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ You'll also need to build [N64Recomp](https://github.com/N64Recomp/N64Recomp) fo
 * First, run `make` (with an optional job count) to build the mod code itself.
 * Next, run the `RecompModTool` utility with `mod.toml` as the first argument and the build dir (`build` in the case of this template) as the second argument.
   * This will produce your mod's `.nrm` file in the build folder.
+  * If you're on MacOS, you may need to specify the path to the `clang` and `ld.lld` binaries using the `CC` and `LD` environment variables, respectively.
 
 ### Updating the Majora's Mask Decompilation Submodule
 Mods can also be made with newer versions of the Majora's Mask decompilation instead of the commit targeted by this repo's submodule.
@@ -35,4 +36,4 @@ To update the commit of the decompilation that you're targeting, follow these st
   * If it fails due to a missing header, create an empty header file in the `include/dummy_headers` folder, with the same path.
     * For example, if it complains that `assets/objects/object_cow/object_cow.h` is missing, create an empty `include/dummy_headers/objects/object_cow.h` file.
   * If RecompModTool fails due to a function "being marked as a patch but not existing in the original ROM", it's likely that function you're patching was renamed in the Majora's Mask decompilation.
-    * Find the relevant function in the map file for the old decomp commit, then go to that address in the new map file, and update the reference to this function in your code with the new name. 
+    * Find the relevant function in the map file for the old decomp commit, then go to that address in the new map file, and update the reference to this function in your code with the new name.


### PR DESCRIPTION
Allows overriding the compiler and linker for macOS since Apple clang won't work.